### PR TITLE
Optimize retrieval of search index.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ PATH_TO_DITA_OT/bin/dita -f html5-bootstrap -o out -i PATH_TO_DITAMAP \
 
 A sample header file with a search box is provided with the plug-in: [includes/bs-navbar-lunr.hdr.xml](./includes/bs-navbar-lunr.hdr.xml).
 
-
 ## License
 
 [Apache 2.0](LICENSE) © 2023 Jason Fox

--- a/README.md
+++ b/README.md
@@ -53,19 +53,15 @@ To download and install a copy, follow the instructions for your operating syste
 
 #### Adding Lunr Search to HTML Bootstrap output
 
-To run, use the `html5-bootstrap` transformation and add the `lunr.search` parameter.
+To run, use the `html5-bootstrap` transformation and add the `args.hdr` parameter.
 
 ```console
 PATH_TO_DITA_OT/bin/dita -f html5-bootstrap -o out -i PATH_TO_DITAMAP \
-  --lunr.search=WEBSITE_URL \
   --args.hdr=path/to/your-header.xml
 ```
 
 A sample header file with a search box is provided with the plug-in: [includes/bs-navbar-lunr.hdr.xml](./includes/bs-navbar-lunr.hdr.xml).
 
-### Parameter Reference
-
-- `lunr.search` - Website URL to search
 
 ## License
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,9 +15,5 @@
   <feature extension="depend.preprocess.post" value="lunr" />
   <!-- Internationalization of texts -->
   <feature extension="dita.xsl.strings" file="cfg/common/vars/strings.xml" />
-
-  <transtype extends="html5-bootstrap" desc="HTML5 with Bootstrap style">
-    <param name="lunr.search" desc="Website URL for Lunr" type="string" />
-  </transtype>
   
 </plugin>

--- a/process_lunr.xml
+++ b/process_lunr.xml
@@ -13,7 +13,7 @@
   <!--
     Setting up Lunr processing. Sets up ANT variables
   -->
-  <target name="lunr.init" if="lunr.search">
+  <target name="lunr.init">
 
     <property
       name="lunr.lib"
@@ -93,7 +93,6 @@
   -->
   <target
     name="lunr.copy.file"
-    if="lunr.search"
     description="Copy lunr-client file"
   >
     <copy
@@ -114,11 +113,6 @@
     />
     <replace
       file="${dita.output.dir}/js/lunr-client.js"
-      token="@@@lunr.search@@@"
-      value="${lunr.search}/"
-    />
-    <replace
-      file="${dita.output.dir}/js/lunr-client.js"
       token="@@@lunr.search.results@@@"
       value="${lunr.search.results}"
     />
@@ -134,7 +128,7 @@
   <!--
     Check if Node.js is installed.
   -->
-  <target name="lunr.node.check" if="lunr.search">
+  <target name="lunr.node.check">
     <!-- For Unix run node as an executable -->
 
     <exec
@@ -174,7 +168,7 @@
   <!--
     Creates placeholder texts for Search Results
   -->
-  <target name="lunr.placeholders" if="lunr.search">
+  <target name="lunr.placeholders">
     <tempfile
       property="lunr.search.results.file"
       deleteonexit="true"
@@ -235,7 +229,7 @@
   <!--
     Generates Lunr search index and preview JSON
   -->
-  <target name="lunr.search.index" if="lunr.search" depends="lunr.lang.support">
+  <target name="lunr.search.index" depends="lunr.lang.support">
       <property name="lunr.raw.json" value="${dita.temp.dir}/lunr.json" />
       <property name="lunr.temp.dir" value="${dita.temp.dir}/lunr" />
       <mkdir dir="${lunr.temp.dir}" />

--- a/process_lunr.xml
+++ b/process_lunr.xml
@@ -91,26 +91,13 @@
   <!--
     Copies the Lunr-client.js file to the final destination
   -->
-  <target
-    name="lunr.copy.file"
-    description="Copy lunr-client file"
-  >
+  <target name="lunr.copy.file" description="Copy lunr-client file">
     <copy
       file="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/lunr-client.js"
       toFile="${dita.output.dir}/js/lunr-client.js"
       overwrite="true"
     />
 
-    <replace
-      file="${dita.output.dir}/js/lunr-client.js"
-      token="@@@lunr.index@@@"
-      value="${lunr.index}"
-    />
-    <replace
-      file="${dita.output.dir}/js/lunr-client.js"
-      token="@@@lunr.preview@@@"
-      value="${lunr.preview}"
-    />
     <replace
       file="${dita.output.dir}/js/lunr-client.js"
       token="@@@lunr.search.results@@@"
@@ -122,7 +109,20 @@
       value="${lunr.no.search.results}"
     />
 
+    <move
+      file="${lunr.index.json}"
+      toFile="${dita.output.dir}/js/search_index.json"
+      overwrite="true"
+    />
+    <move
+      file="${lunr.preview.json}"
+      toFile="${dita.output.dir}/js/preview.json"
+      overwrite="true"
+    />
+
     <chmod file="${dita.output.dir}/js/lunr-client.js" perm="755" />
+    <chmod file="${dita.output.dir}/js/search_index.json" perm="755" />
+    <chmod file="${dita.output.dir}/js/preview.json" perm="755" />
   </target>
 
   <!--
@@ -349,18 +349,6 @@
       id="LUNR002F"
       message="Lunr.js failed to generate search index"
     />
-
-    <loadfile
-      failonerror="true"
-      property="lunr.index"
-      srcfile="${lunr.index.json}"
-    />
-    <loadfile
-      failonerror="true"
-      property="lunr.preview"
-      srcfile="${lunr.preview.json}"
-    />
-
     <!-- Clean up temporary files -->
     <delete failonerror="false" includeemptydirs="true">
       <fileset dir="${lunr.temp.dir}" includes="**/*" />

--- a/resource/lunr-client.js
+++ b/resource/lunr-client.js
@@ -1,6 +1,16 @@
-const LUNR_DATA = @@@lunr.index@@@;
-const PREVIEW_LOOKUP = @@@lunr.preview@@@;
-const BASE_URL = window.location.origin + '/';
+let LUNR_DATA = null;
+let PREVIEW_LOOKUP = null;
+const BASE_URL = window.location.origin + "/";
+
+function jsonFetch(url) {
+  return new Promise(function (resolve, reject) {
+    fetch(BASE_URL + url)
+      .then((response) => response.json())
+      .then((result) => {
+        resolve(result);
+      });
+  });
+}
 
 // Parse search results into HTML
 function parseLunrResults(results) {
@@ -13,7 +23,7 @@ function parseLunrResults(results) {
     const link = item["l"];
     const result =
       '<p><span class="h3"><a href="' +
-      BASE_URL + 
+      BASE_URL +
       link +
       '">' +
       title +
@@ -56,7 +66,15 @@ function closeSearch(el) {
   return false;
 }
 
-function search(el) {
+async function search(el) {
+  if (!LUNR_DATA) {
+    LUNR_DATA = await jsonFetch("js/search_index.json");
+  }
+
+  if (!PREVIEW_LOOKUP) {
+    PREVIEW_LOOKUP = await jsonFetch("js/preview.json");
+  }
+
   const query = document.getElementById("search-input").value;
   const idx = lunr.Index.load(LUNR_DATA);
   // Write results to page
@@ -73,6 +91,6 @@ function search(el) {
   }
 
   elements[0].classList.add("collapse");
-  window.scrollTo(0,0);
+  window.scrollTo(0, 0);
   return false;
 }

--- a/resource/lunr-client.js
+++ b/resource/lunr-client.js
@@ -1,6 +1,6 @@
 const LUNR_DATA = @@@lunr.index@@@;
 const PREVIEW_LOOKUP = @@@lunr.preview@@@;
-const BASE_URL = '@@@lunr.search@@@';
+const BASE_URL = window.location.origin + '/';
 
 // Parse search results into HTML
 function parseLunrResults(results) {


### PR DESCRIPTION
-  Remove unnecessary `lunr.search` DITA parameter, calculate path using `window.location.origin`
- Split search index and preview into separate JSON files and only load on demand.

This  reduces the size of `lunr-client.js` and adds two more files `js/search_index.json` and `js/preview.json`. Note that `lunr-client.js` is always loaded  before `render()` whenever a new page is loaded - OK it could be cached, but it shouldn't be unnecessarily large. With this the larger JSON files are only ever loaded by `fetch()` on demand after a search has been initiated.

These optimisations align with the way that ReadTheDocs uses lunr.js 
