### PR TITLE
Switch window.location.origin for a calculated Script path

### DIFF
--- a/resource/lunr-client.js
+++ b/resource/lunr-client.js
@@ -2,18 +2,22 @@ let LUNR_DATA = null;
 let PREVIEW_LOOKUP = null;
 const scripts = document.getElementsByTagName("script");
 const scriptPath = scripts[scripts.length - 1].src;
-const BASE_URL = scriptPath.substr(0, scriptPath.lastIndexOf("/") + 1);
+const JSON_PATH = scriptPath.substr(0, scriptPath.lastIndexOf("/") + 1);
+const BASE_URL = scriptPath.substr(
+  0,
+  JSON_PATH.lastIndexOf("/", JSON_PATH.lastIndexOf("/") - 1) + 1
+);
 
-function jsonFetch(json, url) {
+function jsonFetch(json, filename) {
   return new Promise(function (resolve, reject) {
     if (json) {
       return resolve(json);
     }
 
-    fetch(BASE_URL + url)
+    fetch(JSON_PATH + filename)
       .then((response) => {
         if (!response.ok) {
-          reject(new Error(`HTTP error, status = ${response.status}`));
+          return reject(new Error(`HTTP error, status = ${response.status}`));
         }
         return response.json();
       })

--- a/resource/lunr-client.js
+++ b/resource/lunr-client.js
@@ -13,7 +13,7 @@ function jsonFetch(json, url) {
     fetch(BASE_URL + url)
       .then((response) => {
         if (!response.ok) {
-           reject(new Error(`HTTP error, status = ${response.status}`));
+          reject(new Error(`HTTP error, status = ${response.status}`));
         }
         return response.json();
       })
@@ -78,13 +78,13 @@ function closeSearch(el) {
 }
 
 function search(el) {
-  jsonFetch(LUNR_DATA, "search_index.json")
-    .then((data) => {
-      LUNR_DATA = data;
-      return jsonFetch(PREVIEW_LOOKUP, "preview.json");
-    })
-    .then((data) => {
-      PREVIEW_LOOKUP = data;
+  Promise.all([
+    jsonFetch(LUNR_DATA, "search_index.json"),
+    jsonFetch(PREVIEW_LOOKUP, "preview.json"),
+  ])
+    .then((values) => {
+      LUNR_DATA = values[0];
+      PREVIEW_LOOKUP = values[1];
       const query = document.getElementById("search-input").value;
       const idx = lunr.Index.load(LUNR_DATA);
       // Write results to page
@@ -106,6 +106,6 @@ function search(el) {
     })
     .catch((e) => {
       console.log(e);
-    })
+    });
   return false;
 }


### PR DESCRIPTION
window.location.origin gets the website name, but not the path under which the document is placed, so it worked for `https://infotexture.github.io`, but not `https://infotexture.github.io/dita-bootstrap/`, this change finds the relative path from the script itself so the correct path is always used.

Should have done more testing.