### PR TITLE
Prepare for initial release to registry

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
   This file is part of the DITA Bootstrap Lunr Search plug-in for DITA Open Toolkit.
   See the accompanying LICENSE file for applicable licenses.
 -->
-<plugin id="net.infotexture.dita-bootstrap.lunr" version="1.0.0">
+<plugin id="net.infotexture.dita-bootstrap.lunr" version="5.3.3">
   <require plugin="net.infotexture.dita-bootstrap"/>
   <feature extension="ant.import" file="process_lunr.xml"/>
   <!-- Ensure the plugin's error and logging messages are available -->


### PR DESCRIPTION
Looks like we've addressed all the open issues here, so we should be ready to package this up for release to [dita-ot/registry](https://github.com/dita-ot/registry) once the corresponding version of [dita-bootstrap](https://github.com/infotexture/dita-bootstrap/) is ready.

- [x] Bump plug-in version attribute to **5.3.3** to reflect the `dita-bootstrap` version it was designed for
- [x] @jason-fox: _anything else?_