### PR TITLE
Fix #23 - Switch link back slash to forward slash

### DIFF
--- a/process_lunr.xml
+++ b/process_lunr.xml
@@ -48,14 +48,6 @@
           token="@@@@@lunr.preview@@@@@"
           value="null"
         />
-        <replace
-          file="${lunr.index.json}"
-          token="/" value="\/"
-        />
-        <replace
-          file="${lunr.preview.json}"
-          token="/" value="\/"
-        />
 
         <move
           file="${lunr.index.json}"
@@ -78,14 +70,6 @@
     -->
     <macrodef name="offline-lunr">
       <sequential>
-        <replace
-          file="${lunr.index.json}"
-          token="/" value="\/"
-        />
-        <replace
-          file="${lunr.preview.json}"
-          token="/" value="\/"
-        />
         <loadfile
           failonerror="true"
           property="lunr.index.placeholder"

--- a/process_lunr.xml
+++ b/process_lunr.xml
@@ -48,6 +48,14 @@
           token="@@@@@lunr.preview@@@@@"
           value="null"
         />
+        <replace
+          file="${lunr.index.json}"
+          token="/" value="\/"
+        />
+        <replace
+          file="${lunr.preview.json}"
+          token="/" value="\/"
+        />
 
         <move
           file="${lunr.index.json}"
@@ -70,6 +78,14 @@
     -->
     <macrodef name="offline-lunr">
       <sequential>
+        <replace
+          file="${lunr.index.json}"
+          token="/" value="\/"
+        />
+        <replace
+          file="${lunr.preview.json}"
+          token="/" value="\/"
+        />
         <loadfile
           failonerror="true"
           property="lunr.index.placeholder"

--- a/xsl/data-to-json.xsl
+++ b/xsl/data-to-json.xsl
@@ -34,7 +34,7 @@
     <xsl:text>",</xsl:text>
 
     <xsl:text>"link": "</xsl:text>
-    <xsl:value-of select="@href"/>
+    <xsl:value-of select="replace(@href, '\\', '/' )"/>
     <xsl:text>",</xsl:text>
 
     <xsl:text>"t": "</xsl:text>

--- a/xsl/data-to-preview.xsl
+++ b/xsl/data-to-preview.xsl
@@ -28,7 +28,7 @@
     <xsl:text>": {</xsl:text>
 
     <xsl:text>"l": "</xsl:text>
-    <xsl:value-of select="@href"/>
+    <xsl:value-of select="replace(@href, '\\', '/' )"/>
     <xsl:text>",</xsl:text>
 
     <xsl:text>"t": "</xsl:text>


### PR DESCRIPTION
Fixes #23, which an issue when:

1. Building an index on Windows.
2. Building an index with deeply embedded folders.

slashes in `link` and `l` are interpreted as escape characters.