### PR TITLE
Line-breaks in topic titles causing builds to fail

### DIFF
--- a/xsl/extract-data.xsl
+++ b/xsl/extract-data.xsl
@@ -38,7 +38,7 @@
 
   <xsl:template match="/dita | *[contains(@class, ' topic/topic ')]">
     <xsl:variable name="TITLE">
-      <xsl:value-of select="replace(*[contains(@class, ' topic/title ')],'&#xA;', ' ')"/>
+      <xsl:value-of select="normalize-space(replace(*[contains(@class, ' topic/title ')],'&#xA;', ' '))"/>
     </xsl:variable>
     <xsl:variable name="KEYWORDS">
       <xsl:for-each


### PR DESCRIPTION
Trailing line breaks within topic `<title>` elements of cause builds to fail when the search result previews are generated (at taskname gen-preview-json). This appears to be when converting the title contents from text node to attribute value in merge-data.xsl. 

Simply wrapping the existing xpath in a normalize-space() function resolves the issue; at least for leading or trailing line breaks.