### PR TITLE
Title Line Breaks Cause Issues in JSON File

### DIFF
--- a/xsl/data-to-json.xsl
+++ b/xsl/data-to-json.xsl
@@ -38,7 +38,7 @@
     <xsl:text>",</xsl:text>
 
     <xsl:text>"t": "</xsl:text>
-    <xsl:value-of select="dita-ot:escapeQuote(@title)"/>
+    <xsl:value-of select="replace(dita-ot:escapeQuote(@title), '\s+', ' ')"/>
     <xsl:text>",</xsl:text>
 
     <xsl:text>"k": "</xsl:text>

--- a/xsl/data-to-json.xsl
+++ b/xsl/data-to-json.xsl
@@ -38,7 +38,7 @@
     <xsl:text>",</xsl:text>
 
     <xsl:text>"t": "</xsl:text>
-    <xsl:value-of select="replace(dita-ot:escapeQuote(@title), '\s+', ' ')"/>
+    <xsl:value-of select="normalize-space(dita-ot:escapeQuote(@title))"/>
     <xsl:text>",</xsl:text>
 
     <xsl:text>"k": "</xsl:text>


### PR DESCRIPTION
This seems related to issue #47 , but it's showing up in a different place. Here, it seems that the line breaks are not being escaped in the resulting lunr.json file for the search functionality.

## Suggested resolution
As the whitespace in a title (whether intentional or not) isn't really relevant to the search functionality, simply using the same replace function in xpath as is used elsewhere in the `data-to-json.xsl` file seems a simple and consistent fix for this issue.

## Configuration
- DITA OT v4.2.3
- net.infotexture.dita-bootstrap.lunr plugin v5.3.4
- Node.js v20.9.0