### PR TITLE
Specify UTF-8 encoding for offline lunr

### DIFF
--- a/process_lunr.xml
+++ b/process_lunr.xml
@@ -74,23 +74,27 @@
           failonerror="true"
           property="lunr.index.placeholder"
           srcfile="${lunr.index.json}"
+          encoding="UTF-8"
         />
         <loadfile
           failonerror="true"
           property="lunr.preview.placeholder"
           srcfile="${lunr.preview.json}"
+          encoding="UTF-8"
         />
 
         <replace
           file="${dita.output.dir}/js/lunr-client.js"
           token="@@@@@lunr.index@@@@@"
           value="${lunr.index.placeholder}"
+          encoding="UTF-8"
         />
 
         <replace
           file="${dita.output.dir}/js/lunr-client.js"
           token="@@@@@lunr.preview@@@@@"
           value="${lunr.preview.placeholder}"
+          encoding="UTF-8"
         />
 
         <copy


### PR DESCRIPTION
We observed an issue with the generation of offline `lunr-client.js` file on Windows machines in which the encoding from some DITA topics were not being carried from XML to JSON to JS file with the correct encoding. This appears due to how Java Ant handles the encoding in the `<loadfile>` and `<replace>` tasks. Java was apparently using some Windows or other encoding (whatever "default JVM character encoding" happens to be instead of UTF-8). Simply specifying the encoding seems to resolve the issue.

## Symptom ##
Bootstrap-HTML output with Lunr search built on a Windows machine/server did not have functioning help. When the file `lunr-client.js` is openend in Oxygen XML Editor, an encoding error is presented (if not disabled in the preferences).