### PR TITLE
Migrate to dita-bootstrap GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://www.dita-ot.org"><img src="https://www.dita-ot.org/images/dita-ot-logo.svg" align="right" height="55"></a>
 
-_DITA Bootstrap Lunr Search_ is a [DITA Open Toolkit plug-in](https://www.dita-ot.org/plugins) that extends the [DITA Bootstrap](https://infotexture.github.io/dita-bootstrap/) HTML output with a [Lunr.js](https://lunrjs.com/) search function.
+_DITA Bootstrap Lunr Search_ is a [DITA Open Toolkit plug-in](https://www.dita-ot.org/plugins) that extends the [DITA Bootstrap](https://dita-bootstrap.github.io/) HTML output with a [Lunr.js](https://lunrjs.com/) search function.
 
 <!-- MarkdownTOC levels="2,3" -->
 
@@ -39,8 +39,8 @@ See the [DITA-OT documentation](https://www.dita-ot.org/4.0/topics/installing-cl
 
 ```console
 dita install https://github.com/jason-fox/fox.jason.extend.css/archive/master.zip
-dita install https://github.com/infotexture/dita-bootstrap/archive/master.zip
-dita install https://github.com/infotexture/dita-bootstrap.lunr/archive/master.zip
+dita install https://github.com/dita-bootstrap/dita-bootstrap/archive/master.zip
+dita install https://github.com/dita-bootstrap/dita-bootstrap.lunr/archive/master.zip
 ```
 
 ### Installing Node.js
@@ -121,7 +121,7 @@ jobs:
 
 ### Parameter Reference
 
-- `offline.mode` - enables Lunr search to work in conjunction with DITA Bootstrap [offline mode](https://infotexture.github.io/dita-bootstrap/offline.html) - this requires an additional plugin to be installed.
+- `offline.mode` - enables Lunr search to work in conjunction with DITA Bootstrap [offline mode](https://dita-bootstrap.github.io/offline.html) - this requires an additional plugin to be installed.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dita-bootstrap.lunr",
   "description": "DITA Open Toolkit plug-in that extends HTML output from the DITA Bootstrap plug-in with a Lunr.js search box",
-  "homepage": "https://github.com/infotexture/dita-bootstrap.lunr",
+  "homepage": "https://github.com/dita-bootstrap/dita-bootstrap.lunr",
   "repository": {
     "type": "git",
-    "url": "https://github.com/infotexture/dita-bootstrap.lunr.git"
+    "url": "https://github.com/dita-bootstrap/dita-bootstrap.lunr.git"
   },
   "license": "Apache-2.0",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,8 +4,8 @@
   This file is part of the DITA Bootstrap Lunr Search plug-in for DITA Open Toolkit.
   See the accompanying LICENSE file for applicable licenses.
 -->
-<plugin id="net.infotexture.dita-bootstrap.lunr" version="5.3.6">
-  <require plugin="net.infotexture.dita-bootstrap"/>
+<plugin id="org.dita-bootstrap.lunr" version="5.3.6">
+  <require plugin="org.dita-bootstrap.html"/>
   <feature extension="ant.import" file="process_lunr.xml"/>
   <!-- Ensure the plugin's error and logging messages are available -->
   <feature extension="dita.xsl.messages" file="resource/messages.xml"/>

--- a/process_lunr.xml
+++ b/process_lunr.xml
@@ -5,7 +5,7 @@
   See the accompanying LICENSE file for applicable licenses.
 -->
 <project
-  name="dita.plugin.net.infotexture.dita-bootstrap.lunr"
+  name="dita.plugin.org.dita-bootstrap.lunr"
   xmlns:if="ant:if"
   xmlns:unless="ant:unless"
 >
@@ -15,7 +15,7 @@
   <target name="lunr.init" description="Setting up Lunr processing">
     <property
       name="lunr.lib"
-      value="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/lunr.js"
+      value="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/lunr.js"
     />
 
     <property name="is.Bootstrap" value="true"/>
@@ -98,7 +98,7 @@
         />
 
         <copy
-          file="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/lunr.js"
+          file="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/lunr.js"
           toFile="${dita.output.dir}/js/lunr.js"
           overwrite="true"
         />
@@ -141,7 +141,7 @@
       createfile="true"
     />
     <copy
-      file="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/node-lunr-base.js"
+      file="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/node-lunr-base.js"
       toFile="${lunr.node.script.file}"
       overwrite="true"
     />
@@ -158,7 +158,7 @@
   >
     <property
       name="lunr.stemmer.js"
-      location="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/languages/lunr.stemmer.support.js"
+      location="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/languages/lunr.stemmer.support.js"
     />
     <loadresource property="lunr.lang">
       <string value="${default.language}"/>
@@ -170,11 +170,11 @@
     </loadresource>
     <property
       name="lunr.lang.js"
-      location="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/languages/lunr.${lunr.lang}.js"
+      location="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/languages/lunr.${lunr.lang}.js"
     />
 
     <copy
-      file="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/node-lunr-lang.js"
+      file="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/node-lunr-lang.js"
       toFile="${lunr.node.script.file}"
       overwrite="true"
     />
@@ -205,7 +205,7 @@
     description="Copy client files to target"
   >
     <copy
-      file="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/lunr-client.js"
+      file="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/lunr-client.js"
       toFile="${dita.output.dir}/js/lunr-client.js"
       overwrite="true"
     />
@@ -297,8 +297,8 @@
     <pipeline taskname="placeholder-search-result">
       <xslt
         classpathref="dost.class.path"
-        style="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/xsl/placeholder-text.xsl"
-        in="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/dummy.xml"
+        style="${dita.plugin.org.dita-bootstrap.lunr.dir}/xsl/placeholder-text.xsl"
+        in="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/dummy.xml"
         out="${lunr.search.results.file}"
       >
         <param name="text" expression="Search Results"/>
@@ -313,8 +313,8 @@
     <pipeline taskname="placeholder-no-search-result">
       <xslt
         classpathref="dost.class.path"
-        style="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/xsl/placeholder-text.xsl"
-        in="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/dummy.xml"
+        style="${dita.plugin.org.dita-bootstrap.lunr.dir}/xsl/placeholder-text.xsl"
+        in="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/dummy.xml"
         out="${lunr.no.search.results.file}"
       >
         <param name="text" expression="No Search Results"/>
@@ -376,7 +376,7 @@
       <xslt
         destdir="${lunr.temp.dir}"
         extension="xml"
-        style="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/xsl/extract-data.xsl"
+        style="${dita.plugin.org.dita-bootstrap.lunr.dir}/xsl/extract-data.xsl"
         filenameparameter="FILENAME"
         filedirparameter="FILEDIR"
         parallel="${parallel}"
@@ -392,9 +392,9 @@
     <xslt
       taskname="merge-texts"
       force="true"
-      in="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/resource/dummy.xml"
+      in="${dita.plugin.org.dita-bootstrap.lunr.dir}/resource/dummy.xml"
       out="${lunr.raw.xml}"
-      style="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/xsl/merge-data.xsl"
+      style="${dita.plugin.org.dita-bootstrap.lunr.dir}/xsl/merge-data.xsl"
     >
       <xmlcatalog refid="dita.catalog"/>
       <param expression="${lunr.temp.dir}/" name="in"/>
@@ -406,14 +406,14 @@
       taskname="gen-raw-json"
       in="${lunr.raw.xml}"
       out="${lunr.raw.json}"
-      style="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/xsl/data-to-json.xsl"
+      style="${dita.plugin.org.dita-bootstrap.lunr.dir}/xsl/data-to-json.xsl"
     />
 
     <xslt
       taskname="gen-preview-json"
       in="${lunr.raw.xml}"
       out="${lunr.preview.json}"
-      style="${dita.plugin.net.infotexture.dita-bootstrap.lunr.dir}/xsl/data-to-preview.xsl"
+      style="${dita.plugin.org.dita-bootstrap.lunr.dir}/xsl/data-to-preview.xsl"
     />
 
     <property name="lunr.raw.json.file" location="${lunr.raw.json}"/>


### PR DESCRIPTION
- Rename plug-in ID `net.infotexture.dita-bootstrap.lunr` → `org.dita-bootstrap.lunr` in plugin.xml and the corresponding Ant project name and `${dita.plugin.*.dir}` properties in process_lunr.xml.
- Update `<require>` from `net.infotexture.dita-bootstrap` → `org.dita-bootstrap.html`.
- Update GitHub URLs from `infotexture/*` → `dita-bootstrap/*` and the GitHub Pages site `infotexture.github.io/dita-bootstrap` → `dita-bootstrap.github.io`.